### PR TITLE
github enterprise support

### DIFF
--- a/issues.js
+++ b/issues.js
@@ -27,29 +27,29 @@ $(function () {
       chrome.storage.sync.get(href, function (data) {
         var voters = data[href] || []
           , other_voters = _(voters).without(my_username)
-          , $p = $('<p style="position: absolute; right: -25px; top: 10px; "><img class="emoji" title=":+1:" alt=":+1:" src="https://a248.e.akamai.net/assets.github.com/images/icons/emoji/+1.png" height="20" width="20" align="absmiddle"></p>');
+          , $thumbsup = $('<img class="emoji" title=":+1:" alt=":+1:" src="/images/icons/emoji/+1.png" height="16" width="16" align="absmiddle"/>')
+          , $list_item = $a.parents('.issue-list-item');
 
         // Add my own thumb if I already approved this PR
         if (voters.indexOf(my_username) !== -1) {
-          $a.parents('.info-wrapper').append($p);
-          $p.find('img').attr({ title: voters.join(", ") });
+          $thumbsup.attr({ title: voters.join(", ") });
+          $list_item.find('.list-group-item-meta').append($thumbsup);
         }
 
         // Show the count of other people's votes
         if (other_voters.length) {
-          var $list_item = $a.parents('.list-browser-item')
-            , $p = $('<p style="position: absolute; right: -57px; top: 10px; font-size: 18px; cursor: default;">+ ' + other_voters.length + '</p>');
+          var $p = $('<li>+&nbsp;' + other_voters.length + '</li>');
 
           $p.attr({ title: voters.join(", ") });
 
           // If more than 2 people voted it, color it green and push it to the bottom
           if (other_voters.length >= 2) {
             $list_item.css({ 'background-color': 'rgba(0, 255, 0, 0.1)' });
-            $list_item.parents('tbody').append($list_item);
+            $list_item.parents('.issue-list-group').append($list_item);
           }
 
           // Add number of votes
-          $a.parents('.info-wrapper').append($p);
+          $list_item.find('.list-group-item-meta').append($p);
         }
       });
     });

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
     "background"]
 , "content_scripts": [
     {
-      "matches": ["https://github.com/*"]
+      "matches": ["https://github.com/*", "*://*/*/issues*", "*://*/*/pull/*"]
     , "js": ["lib/jquery-1.8.2.js","lib/underscore.js","lib/underscore_mixins.js","pull.js","issues.js"]
     }
   ]

--- a/pull.js
+++ b/pull.js
@@ -20,7 +20,7 @@
     var voted_by = [];
 
     $(".comment-header-author").each(function () {
-      if ($(this).parents(".discussion-bubble-inner").find("img[title=':+1:']").length) {
+      if ($(this).parents(".discussion-bubble-inner").find("img[title=':+1:'],img[title=':thumbsup:']").length) {
         voted_by.push($(this).text());
       }
     });
@@ -33,7 +33,6 @@
     var hash = {};
     hash[pr_key] = usersWhoVoted();
     chrome.storage.sync.get(pr_key, function (stored) {
-      console.log(hash[pr_key], stored[pr_key], hash[pr_key] !== stored[pr_key]);
       if (hash[pr_key] !== stored[pr_key]) {
         chrome.storage.sync.set(hash);
       }


### PR DESCRIPTION
supports markup from the current GHE release 11.10.332 (Apr 23, 2014)

don't know if this extension actually still works (before or after this patch) with the current public github but this makes it work on our private instance.
